### PR TITLE
Added the rest of the html for the yaml

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -105,11 +105,30 @@ hr {
 div[class^="action-"],
 div[class^="descriptions-title-"],
 .Skills-content .types-list-title,
+#System-Combat-Attacking-title,
+#System-Combat-Opposing-title,
+div[id^="System-Equipment-title-"],
 .Derived-Attributes-content .types-list-title {
 	text-align: center;
 	background-color: #70a1cc;
 	color: black;
 	font-weight: bold;
+}
+
+.System-Combat-Attacking-body,
+div[id^="System-Equipment-body-"],
+.System-Combat-Opposing-body {
+	padding: 5px;
+}
+
+#System-Combat-Attacking-Steps ol,
+#System-Combat-Opposing-Steps ol {
+	font-weight: bold;
+}
+
+#System-Combat-Attacking-Steps li span,
+#System-Combat-Opposing-Steps li span {
+	font-weight: normal;
 }
 
 div[class^="descriptions-title-"] {
@@ -180,7 +199,8 @@ div[class$="-system-Equipment-title"],
 .subActions-item-desc {}
 
 .subActions-item-noRoll span,
-.subActions-item-desc span {
+.subActions-item-desc span,
+.subActions-item-action-points span {
 	font-weight: bold;
 }
 

--- a/public/assets/scripts/templateEngine.js
+++ b/public/assets/scripts/templateEngine.js
@@ -119,6 +119,9 @@ window.onload = function () {
     getSystemPartial("systemFeatsPartial", "system_feats_partial");
     getSystemPartial("descriptionsTextPartial", "descriptions_text_partial");
     getSystemPartial("systemEquipmentPartial", "system_equipment_partial");
+    getSystemPartial("actionResolutionPartial", "system_action_resolution_partial");
+    getSystemPartial("timeResolutionPartial", "system_time_resolution_partial");
+    getSystemPartial("combatPartial", "system_combat_partial");
 
   var cacheBuster = "?" + Date.now()
 
@@ -137,6 +140,7 @@ window.onload = function () {
   var data = deepmerge.all([characterData, systemData, actionData, simpleActionData, featData, weaponData, armorData]);
   //console.log(Handlebars.partials);
   console.log(data);
+
   //console.log(Handlebars.partials)
 
   //Render the data into the template

--- a/public/data/Armor.yaml
+++ b/public/data/Armor.yaml
@@ -10,6 +10,7 @@ System:
         ModificationNotation:
           SubType: Grouping of modifications. In general you may only have one from each category.
           GeneralNotation: -> Is used to indicate a sub item.
+          Examples:
             IE1: Reduction -> -1 (Reduce the reduction by one)
             IE2: Special -> +Something (Add an aditional special)
             IE3: Special -> -Something (Remove an exsting special)

--- a/public/data/Weapons.yaml
+++ b/public/data/Weapons.yaml
@@ -9,6 +9,7 @@ System:
         ModificationNotation:
           SubType: Grouping of modifications. In general you may only have one from each category.
           GeneralNotation: -> Is used to indicate a sub item.
+          Examples:
             IE1: Difficulty -> -1 (Reduce the difficulty by one)
             IE2: Special -> +Something (Add an aditional special)
             IE3: Special -> -Something (Remove an exsting special)

--- a/public/partials/system/descriptions_text_partial
+++ b/public/partials/system/descriptions_text_partial
@@ -4,6 +4,14 @@
 </div>
 {{/if}}
 
+{{#compare ap "true" operator="=="}}
+  {{#if [Action Cost] }}
+  <div class="subActions-item-action-points">
+    <span>Action Cost:</span> {{[Action Cost]}}
+  </div>
+  {{/if}}
+{{/compare}}
+ 
 {{#if NoRoll}}
 <div class="subActions-item-noRoll">
     <span>No Roll:</span> {{[NoRoll]}}

--- a/public/partials/system/system_action_partial
+++ b/public/partials/system/system_action_partial
@@ -2,7 +2,7 @@
     <div class="descriptions-{{@../../key}}-{{@key}}">
         <div class="descriptions-title-{{@../../key}}-{{@key}}"><b>{{@key}}:</b></div>
         <div class="descriptions-body-{{@../../key}}-{{@key}}">
-            {{> descriptionsTextPartial}}
+            {{> descriptionsTextPartial ap="true"}}
         </div>
     </div>
 {{else}}
@@ -23,7 +23,7 @@
                       </div>
                   </div>
                   <div class="subActions-item--body">
-                      {{> descriptionsTextPartial}}
+                      {{> descriptionsTextPartial ap="false"}}
                   </div>
               </div>
             {{/each}}

--- a/public/partials/system/system_action_resolution_partial
+++ b/public/partials/system/system_action_resolution_partial
@@ -1,0 +1,12 @@
+<hr>
+<p id="System-Action-Resolution-Opposed-Actions" class="section-desc">
+	<span><b>Opposed Actions:</b></span>&nbsp;{{[Opposed Actions]}}
+</p>
+
+<p id="System-Action-Resolution-Threshold-Calculation-Example" class="section-desc">
+	<span><b>Threshold Calculation Example:</b></span>&nbsp;{{[Threshold Calculation Example]}}
+</p>
+
+<p id="System-Action-Resolution-Unopposed-Actions" class="section-desc">
+	<span><b>Unopposed Actions:</b></span>&nbsp;{{[Unopposed Actions]}}
+</p>

--- a/public/partials/system/system_combat_partial
+++ b/public/partials/system/system_combat_partial
@@ -1,0 +1,31 @@
+<hr>
+<div id="System-Combat-Attacking">
+	<div id="System-Combat-Attacking-title">Attacking: </div>
+	<div class="System-Combat-Attacking-body">
+		{{Attacking.Description}}
+		<div id="System-Combat-Attacking-Steps">
+			<b>Steps: </b>
+			<ol>
+				{{#each Attacking.Steps}}
+					<li><span>{{this}}</span></li>
+				{{/each}}
+			</ol>
+		</div>
+	</div>
+</div>
+
+<div id="System-Combat-Opposing">
+	<div id="System-Combat-Opposing-title">Opposing: </div>
+	<div class="System-Combat-Opposing-body">
+		{{Opposing.Description}}
+		<div><b>Cost:</b>&nbsp;{{Opposing.Cost}}</div>
+		<div id="System-Combat-Opposing-Steps">
+			<b>Steps: </b>
+			<ol>
+				{{#each Opposing.Steps}}
+					<li><span>{{this}}</span></li>
+				{{/each}}
+			</ol>
+		</div>
+	</div>
+</div>

--- a/public/partials/system/system_descriptions_partial
+++ b/public/partials/system/system_descriptions_partial
@@ -17,12 +17,6 @@
                 {{/ systemFeatsPartial}}
               {{/equal}}
 
-              {{#equal @../key 'Equipment'}}
-                {{#> systemEquipmentPartial this}}
-                  <div class="text-center">Equipment partial suppose to go here.</div>
-                {{/systemEquipmentPartial}}
-              {{/equal}}
-
             {{/each}}
         </ul>
     </div>

--- a/public/partials/system/system_equipment_partial
+++ b/public/partials/system/system_equipment_partial
@@ -1,48 +1,88 @@
-<div id="system-wrapper-{{@../../key}}-{{@key}}">
-	<div class="row {{@key}}-system-{{@../../key}}-title">
-		<div class="col-md-6">
-        <b>{{@key}}</b>
-    </div>
-    <div class="col-md-6 Equipment-heading-right">
-      <span>Difficulty:</span> {{[Difficulty]}}
-	  </div>
-	</div>
-	<div class="system-{{@../../key}}-{{@key}}-body">
-		{{#each .}}
-			{{#compare @key 'Difficulty' operator='!='}}
-				{{#ifObject .}}
-					<b>{{@key}}:</b> 
+<div id="System-Equipment">
+	{{#each .}}
+		{{#compare @key "Description" operator="!="}}
+			<div id="System-Equipment-title-{{@key}}">{{@key}}</div>
+			<div id="System-Equipment-body-{{@key}}">
+				<div id="System-Equipment-Notations">
+					<span><b>Notations:</b></span>
 					<ul>
-						{{#each .}}
-						<li>
-							<b>{{@key}}:</b> 
-							{{#ifObject .}}
-								<ul>
-									{{#each .}}
-									<li>
-										<b>{{@key}}:</b> 
-										{{#ifArray .}}
-											<ul>
-												{{#each .}}
-													<li>{{this}}</li>
-												{{/each}}
-											</ul>
-										{{else}}
-											{{this}}
-										{{/ifArray}}
-									</li>
-									{{/each}}
-								</ul>
-							{{else}}
-								{{this}}
-							{{/ifObject}}
-						</li>
+						{{#each Notations}}
+							<li>
+								{{#ifObject .}}
+									<span><b>{{@key}}:&nbsp;</b></span>
+									<ul>
+										{{#each .}}
+											<li>
+												{{#ifObject .}}
+													<span><b>{{@key}}:&nbsp;</b></span>
+													<ul>
+														{{#each .}}
+															<li><span><b>{{@key}}:&nbsp;</b></span>{{this}}</li>
+														{{/each}}
+													</ul>
+												{{else}}
+													{{this}}
+												{{/ifObject}}
+											</li>
+										{{/each}}
+									</ul>
+								{{else}}
+									<span><b>{{@key}}:&nbsp;</b></span>{{this}}
+								{{/ifObject}}
+							</li>
 						{{/each}}
 					</ul>
-				{{else}}	
-					<b>{{@key}}:</b> {{this}} <br>
-				{{/ifObject}}
-			{{/compare}}
-		{{/each}}
-	</div>
+				</div>
+				<div id="System-Equipment-Descriptions">
+					<span><b>Descriptions:</b></span>
+					<ul>
+						{{#each Descriptions}}
+							<li>
+								{{#ifObject .}}
+									<span><b>{{@key}}:&nbsp;</b></span>
+									<ul>
+										{{#each .}}
+											<li>
+												<span><b>{{@key}}:&nbsp;</b></span>
+												{{#ifObject .}}
+													<ul>
+														{{#each .}}
+															<span><b>{{@key}}:&nbsp;</b></span>
+												{{#ifObject .}}
+													<ul>
+														{{#each .}}
+															<li><span><b>{{@key}}:&nbsp;</b></span>
+															{{#ifArray .}}
+																<ul>
+																	{{#each .}}
+																		<li>{{this}}</li>
+																	{{/each}}
+																</ul>
+															{{else}}
+																{{this}}
+															{{/ifArray}}
+															</li>
+														{{/each}}
+													</ul>
+												{{else}}
+													{{this}}
+												{{/ifObject}}
+														{{/each}}
+													</ul>
+												{{else}}
+													{{this}}
+												{{/ifObject}}
+											</li>
+										{{/each}}
+									</ul>
+								{{else}}
+									<span><b>{{@key}}:&nbsp;</b></span>{{this}}
+								{{/ifObject}}
+							</li>
+						{{/each}}
+					</ul>
+				</div>
+			</div>
+		{{/compare}}
+	{{/each}}
 </div>

--- a/public/partials/system/system_partial
+++ b/public/partials/system/system_partial
@@ -12,6 +12,37 @@
             <div class="section--panel-body panel-body">
                 {{#if Description}}<p class="section-desc">{{Description}}</p>{{/if }}
                 
+                {{#compare @index 1 operator="=="}}<hr>{{/compare}}
+                {{#compare @key "Actions" operator="=="}}<hr>{{/compare}}
+                
+                <!-- Action Resolution -->
+                {{#compare @key "Action Resolution" operator="==" }}
+                    {{#> actionResolutionPartial this}}
+                        <span>actionResolution</span>
+                    {{/ actionResolutionPartial}}
+                {{/compare}}
+
+                <!-- Combat -->
+                {{#compare @key "Combat" operator="==" }}
+                    {{#> combatPartial this}}
+                        <span>combatPartial</span>
+                    {{/ combatPartial}}
+                {{/compare}}
+
+                <!-- Combat -->
+                {{#compare @key "Time Resolution" operator="==" }}
+                    {{#> timeResolutionPartial this}}
+                        <span>timeResolutionPartial</span>
+                    {{/ timeResolutionPartial}}
+                {{/compare}}
+
+                <!-- Equipment -->
+                {{#compare @key "Equipment" operator="==" }}
+                    {{#> systemEquipmentPartial this}}
+                      <div class="text-center">Equipment partial suppose to go here.</div>
+                    {{/systemEquipmentPartial}}
+                {{/compare}}
+                
                 <!-- Types -->
                 {{#if Types}} {{#> systemActionTypesPartial this}}{{/ systemActionTypesPartial}} {{/if }}
                 

--- a/public/partials/system/system_time_resolution_partial
+++ b/public/partials/system/system_time_resolution_partial
@@ -1,0 +1,10 @@
+<p id="System-Time-Resolution-Opposed-Actions" class="section-desc">
+	<span><b>Free Play: </b></span>&nbsp;{{[Free Play].Description}}
+</p>
+
+<p id="System-Time-Resolution-Rounds" class="section-desc">
+	<span><b>Rounds:</b></span>&nbsp;{{Rounds.Description}}
+	<ul>
+		<li><div><span><b>Action Points:</b></span>&nbsp; {{Rounds.[Action Points]}}</div></li>
+	</ul>
+</p>


### PR DESCRIPTION
So there is a bit of an yaml issue.
![issue](https://user-images.githubusercontent.com/1609984/29699155-8171ff36-8928-11e7-8647-01f3642ebf9e.PNG)

So Under **ModificationNotation** there is this text -> 
`-> Is used to indicate a sub item. IE1: Difficulty -> -1 (Reduce the difficulty by one) IE2: Special -> +Something (Add an aditional special) IE3: Special -> -Something (Remove an exsting special) IE4: Damage -> d6 (Damage becomes a d6) IE5: Parry -> Difficulty -> +2 (The difficulty of parry increases by 2) IE6: Fient -> Difficulty -> -4 (The difficulty of fient decreases by 4)` 

that's suppose to be an object (or array?) except it's a string with return carriages in it. which would be fine except html doesn't read the return carriages. 